### PR TITLE
test_pkg: 1.3.1-3 in 'kinetic-sqint/distribution.yaml' [bloom]

### DIFF
--- a/kinetic-sqint/distribution.yaml
+++ b/kinetic-sqint/distribution.yaml
@@ -2,11 +2,9 @@
 # ROS distribution file
 # see REP 143: http://ros.org/reps/rep-0143.html
 ---
-tags:
-  - custom
 release_platforms:
   ubuntu:
-    - xenial
+  - xenial
 repositories:
   test_pkg:
     doc:
@@ -17,12 +15,14 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: git@github.com:Solteq/inventory-robot-ros-test-release.git
-      version: 1.3.1-1
+      version: 1.3.1-3
     source:
       test_pull_requests: true
       type: git
       url: git@github.com:Solteq/inventory-robot-ros-test.git
       version: kinetic-develop
     status: developed
+tags:
+- custom
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `test_pkg` to `1.3.1-3`:

- upstream repository: https://github.com/Solteq/inventory-robot-ros-test.git
- release repository: git@github.com:Solteq/inventory-robot-ros-test-release.git
- distro file: `kinetic-sqint/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.3.1-1`
