### PR TITLE
core_pkg: 0.3.2-1 in 'kinetic-sqint/distribution.yaml' [bloom]

### DIFF
--- a/kinetic-sqint/distribution.yaml
+++ b/kinetic-sqint/distribution.yaml
@@ -6,6 +6,22 @@ release_platforms:
   ubuntu:
   - xenial
 repositories:
+  core_pkg:
+    doc:
+      type: git
+      url: git@github.com:Solteq/inventory-robot-ros-core.git
+      version: kinetic-develop
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/Solteq/inventory-robot-ros-core-release.git
+      version: 0.3.2-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: git@github.com:Solteq/inventory-robot-ros-core.git
+      version: kinetic-develop
+    status: developed
   test_pkg:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `core_pkg` to `0.3.2-1`:

- upstream repository: https://github.com/Solteq/inventory-robot-ros-core.git
- release repository: https://github.com/Solteq/inventory-robot-ros-core-release.git
- distro file: `kinetic-sqint/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`

## core_pkg

```
* Add type declaration for boost::any class #43 <https://github.com/Solteq/inventory-robot-ros-core/issues/43>
```
