### PR TITLE
test_pkg: 1.3.2-1 in 'kinetic-sqint/distribution.yaml' [bloom]

### DIFF
--- a/kinetic-sqint/distribution.yaml
+++ b/kinetic-sqint/distribution.yaml
@@ -4,7 +4,7 @@
 ---
 release_platforms:
   ubuntu:
-    - xenial
+  - xenial
 repositories:
   core_pkg:
     doc:
@@ -31,7 +31,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: git@github.com:Solteq/inventory-robot-ros-test-release.git
-      version: 1.3.1-3
+      version: 1.3.2-1
     source:
       test_pull_requests: true
       type: git
@@ -39,6 +39,6 @@ repositories:
       version: kinetic-develop
     status: developed
 tags:
-  - custom
+- custom
 type: distribution
 version: 2


### PR DESCRIPTION
Increasing version of package(s) in repository `test_pkg` to `1.3.2-1`:

- upstream repository: https://github.com/Solteq/inventory-robot-ros-test.git
- release repository: git@github.com:Solteq/inventory-robot-ros-test-release.git
- distro file: `kinetic-sqint/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.3.1-3`

## test_pkg

```
* Perkele ...
```
