### PR TITLE
air_core_pkg: 0.2.3-1 in 'kinetic-sqint/distribution.yaml' [bloom]

### DIFF
--- a/kinetic-sqint/distribution.yaml
+++ b/kinetic-sqint/distribution.yaml
@@ -14,7 +14,7 @@ repositories:
     release:
       tags:
         release: release/kinetic/{package}/{version}
-      url: https://github.com/Solteq/inventory-robot-ros-air-core-release.git
+      url: git@github.com:Solteq/inventory-robot-ros-air-core-release.git
       version: 0.2.3-1
     source:
       test_pull_requests: true

--- a/kinetic-sqint/distribution.yaml
+++ b/kinetic-sqint/distribution.yaml
@@ -6,6 +6,22 @@ release_platforms:
   ubuntu:
   - xenial
 repositories:
+  air_core_pkg:
+    doc:
+      type: git
+      url: git@github.com:Solteq/inventory-robot-ros-air-core.git
+      version: kinetic-develop
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: https://github.com/Solteq/inventory-robot-ros-air-core-release.git
+      version: 0.2.3-1
+    source:
+      test_pull_requests: true
+      type: git
+      url: git@github.com:Solteq/inventory-robot-ros-air-core.git
+      version: kinetic-develop
+    status: developed
   core_pkg:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `air_core_pkg` to `0.2.3-1`:

- upstream repository: https://github.com/Solteq/inventory-robot-ros-air-core.git
- release repository: https://github.com/Solteq/inventory-robot-ros-air-core-release.git
- distro file: `kinetic-sqint/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`
