### PR TITLE
cpr: 1.3.0-1 in 'kinetic-sqint/distribution.yaml' [bloom]

### DIFF
--- a/kinetic-sqint/distribution.yaml
+++ b/kinetic-sqint/distribution.yaml
@@ -38,6 +38,13 @@ repositories:
       url: git@github.com:Solteq/inventory-robot-ros-core.git
       version: kinetic-develop
     status: developed
+  cpr:
+    release:
+      tags:
+        release: release/kinetic/{package}/{version}
+      url: git@github.com:Solteq/vendors-cpr.git
+      version: 1.3.0-1
+    status: maintained
   test_pkg:
     doc:
       type: git


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr` to `1.3.0-1`:

- upstream repository: git@github.com:Solteq/vendors-cpr.git
- release repository: git@github.com:Solteq/vendors-cpr.git
- distro file: `kinetic-sqint/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `null`
