### PR TITLE
cpr: 1.3.0-5 in 'kinetic-sqint/distribution.yaml' [bloom]

### DIFF
--- a/kinetic-sqint/distribution.yaml
+++ b/kinetic-sqint/distribution.yaml
@@ -43,7 +43,7 @@ repositories:
       tags:
         release: release/kinetic/{package}/{version}
       url: git@github.com:Solteq/vendors-cpr.git
-      version: 1.3.0-4
+      version: 1.3.0-5
     status: maintained
   test_pkg:
     doc:


### PR DESCRIPTION
Increasing version of package(s) in repository `cpr` to `1.3.0-5`:

- upstream repository: git@github.com:Solteq/vendors-cpr.git
- release repository: git@github.com:Solteq/vendors-cpr.git
- distro file: `kinetic-sqint/distribution.yaml`
- bloom version: `0.9.0`
- previous version for package: `1.3.0-4`
